### PR TITLE
Add support for inline blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Code lines are automatically trimmed and always completely invisible in the outp
 % }
 ```
 
-You can also capture whole template blocks as `async` functions for reuse later with `<{blockName}>` and
+#### Named Blocks
+
+You can also capture whole template blocks as named `async` functions for reuse later with `<{blockName}>` and
 `<{/blockName}>` tags. Similar to code lines, these tags are automatically trimmed and invisible in the output. The use
 of named parameters is optional.
 
@@ -114,6 +116,17 @@ of named parameters is optional.
 ```
 
 To generate template blocks you can use `<{{blockName}}>` and `<{{/blockName}}>` tags.
+
+#### Inline Blocks
+
+To capture template blocks as anonymous `async` functions, for example to pass them as arguments to helper functions,
+you can use `{{{` and `}}}`.
+
+```
+<% const hello = await foo('bar', {{{
+  Hello World!
+<% }}}, 'baz'); %>
+```
 
 ### Debugging
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To capture template blocks as anonymous `async` functions, for example to pass t
 you can use `{{{` and `}}}`.
 
 ```
-<% const hello = await foo('bar', {{{
+<%= await foo('bar', {{{
   Hello World!
 <% }}}, 'baz'); %>
 ```

--- a/test/template.js
+++ b/test/template.js
@@ -478,6 +478,10 @@ foo:<%%= await foo() %>
 
   await t.test('Inline blocks', async t => {
     t.equal(await Template.render('<% const foo = {{{ %>Foo<% }}}; %>foo:<%= await foo() %>'), 'foo:Foo');
+    t.equal(await Template.render('<% const foo ={{{ %>Foo<% }}};%>foo:<%= await foo() %>'), 'foo:Foo');
+    t.equal(await Template.render('<% const foo = {{{%>Foo<%}}}; %>foo:<%= await foo() %>'), 'foo:Foo');
+    t.equal(await Template.render('<% const foo={{{%>Foo<%}}};%>foo:<%= await foo() %>'), 'foo:Foo');
+    t.equal(await Template.render('<% const foo =  {{{  %>Foo<%  }}} ; %>foo:<%= await foo() %>'), 'foo:Foo');
 
     const block = `
 % const foo = {{{
@@ -486,5 +490,14 @@ foo:<%%= await foo() %>
 foo:<%= await foo() %>
 `;
     t.equal(await Template.render(block), '\nfoo:  Foo\n\n');
+
+    // Does not yet work
+    const blockHelper = `
+% const foo = async (fn) => await fn();
+%= foo({{{
+  Bar
+% }}});
+    `;
+    t.equal(await Template.render(blockHelper), '\n  Bar\n\n');
   });
 });

--- a/test/template.js
+++ b/test/template.js
@@ -475,4 +475,16 @@ foo:<%%= await foo() %>
     t.equal(await Template.render('foo}>'), 'foo}>');
     t.equal(await Template.render('<{{...}}>'), '<{{...}}>');
   });
+
+  await t.test('Inline blocks', async t => {
+    t.equal(await Template.render('<% const foo = {{{ %>Foo<% }}}; %>foo:<%= await foo() %>'), 'foo:Foo');
+
+    const block = `
+% const foo = {{{
+  Foo
+% }}};
+foo:<%= await foo() %>
+`;
+    t.equal(await Template.render(block), '\nfoo:  Foo\n\n');
+  });
 });


### PR DESCRIPTION
This is a prototype for inline blocks, as an alternative to named blocks. Together they provide pretty much the same functionality as `begin`/`end` in the Perl version. The implementation should be pretty ok, but i'm still not entirely sure about the actual syntax. `{{{` and `}}}` were simply the best suggestions that have come up so far.